### PR TITLE
Fix NanoFlow sampling to use current denoised state instead of initial noise

### DIFF
--- a/rectified_flow_pytorch/nano_flow.py
+++ b/rectified_flow_pytorch/nano_flow.py
@@ -47,7 +47,7 @@ class NanoFlow(Module):
             time = time.expand(batch_size)
             time_kwarg = {self.times_cond_kwarg: time} if exists(self.times_cond_kwarg) else dict()
 
-            pred_flow = self.model(noise, **time_kwarg, **kwargs)
+            pred_flow = self.model(denoised, **time_kwarg, **kwargs)
             denoised = denoised + delta * pred_flow
 
         return denoised


### PR DESCRIPTION
During sampling, we need to use the current position represented by `denoised` as the input to the model, as we seek the velocity field to iteratively update the position. `noise` just represents the initialized state, not the current position. 