### PR TITLE
Add SplitMeanFlow implementation (arxiv:2507.16884)

### DIFF
--- a/rectified_flow_pytorch/__init__.py
+++ b/rectified_flow_pytorch/__init__.py
@@ -13,3 +13,5 @@ from rectified_flow_pytorch.reflow import (
     Reflow,
     ReflowTrainer
 )
+
+from rectified_flow_pytorch.split_mean_flow import SplitMeanFlow

--- a/rectified_flow_pytorch/rectified_flow.py
+++ b/rectified_flow_pytorch/rectified_flow.py
@@ -555,6 +555,7 @@ class Block(Module):
         self.dropout = nn.Dropout(dropout)
 
     def forward(self, x, scale_shift = None):
+        x = x.contiguous()
         x = self.proj(x)
         x = self.norm(x)
 

--- a/rectified_flow_pytorch/split_mean_flow.py
+++ b/rectified_flow_pytorch/split_mean_flow.py
@@ -1,0 +1,323 @@
+# https://arxiv.org/abs/2507.16884
+
+from random import random
+from contextlib import nullcontext
+
+import torch
+from torch import tensor, ones, zeros
+from torch.nn import Module
+import torch.nn.functional as F
+
+from einops import reduce
+
+def exists(v):
+    return v is not None
+
+def xnor(x, y):
+    return not (x ^ y)
+
+def default(v, d):
+    return v if exists(v) else d
+
+def identity(t):
+    return t
+
+def append_dims(t, dims):
+    shape = t.shape
+    ones = ((1,) * dims)
+    return t.reshape(*shape, *ones)
+
+class SplitMeanFlow(Module):
+    def __init__(
+        self,
+        model: Module,
+        data_shape = None,
+        normalize_data_fn = identity,
+        unnormalize_data_fn = identity,
+        use_adaptive_loss_weight = True,
+        adaptive_loss_weight_p = 0.5, # 0.5 is approximately pseudo huber loss
+        use_logit_normal_sampler = True,
+        logit_normal_mean = -.4,
+        logit_normal_std = 1.,
+        prob_default_flow_obj = 0.5,
+        add_recon_loss = False,
+        recon_loss_weight = 1.,
+        accept_cond = False,
+        noise_std_dev = 1.,
+        eps = 1e-3
+    ):
+        super().__init__()
+        self.model = model # model must accept three arguments in the order of (<noised data>, <times>, <integral start times>, <maybe condition?>)
+        self.data_shape = data_shape
+
+        # weight loss related
+
+        self.use_adaptive_loss_weight = use_adaptive_loss_weight
+        self.adaptive_loss_weight_p = adaptive_loss_weight_p
+        self.eps = eps
+
+        # time sampler
+
+        self.use_logit_normal_sampler = use_logit_normal_sampler
+        self.logit_normal_mean = logit_normal_mean
+        self.logit_normal_std = logit_normal_std
+
+        # norm / unnorm data
+
+        self.normalize_data_fn = normalize_data_fn
+        self.unnormalize_data_fn = unnormalize_data_fn
+
+        # they do 25-50% normal flow matching obj for boundary condition
+
+        assert 0. <= prob_default_flow_obj <= 1.
+        self.prob_default_flow_obj = prob_default_flow_obj
+
+        # recon loss
+
+        self.add_recon_loss = add_recon_loss and recon_loss_weight > 0
+        self.recon_loss_weight = recon_loss_weight
+
+        # accepting conditioning
+
+        self.accept_cond = accept_cond
+
+        self.noise_std_dev = noise_std_dev
+
+        self.register_buffer('dummy', tensor(0), persistent = False)
+
+    @property
+    def device(self):
+        return self.dummy.device
+
+    def sample_times(self, batch):
+        shape, device = (batch,), self.device
+
+        if not self.use_logit_normal_sampler:
+            return torch.rand(shape, device = device)
+
+        mean = torch.full(shape, self.logit_normal_mean, device = device)
+        std = torch.full(shape, self.logit_normal_std, device = device)
+        return torch.normal(mean, std).sigmoid()
+
+    def get_noise(
+        self,
+        batch_size = 1,
+        data_shape = None
+    ):
+        device = self.device
+
+        data_shape = default(data_shape, self.data_shape)
+        assert exists(data_shape), 'shape of the data must be passed in, or set at init or during training'
+
+        noise = torch.randn((batch_size, *data_shape), device = device) * self.noise_std_dev
+        return noise
+
+    @torch.no_grad()
+    def slow_sample(
+        self,
+        steps = 16,
+        batch_size = 1,
+        noise = None,
+        cond = None,
+        data_shape = None,
+        **kwargs
+    ):
+        assert steps >= 1
+
+        device = self.device
+
+        if not exists(noise):
+            noise = self.get_noise(batch_size, data_shape = data_shape)
+
+        times = torch.linspace(1., 0., steps + 1, device = device)[:-1]
+        delta = 1. / steps
+
+        denoised = noise
+
+        maybe_cond = (cond,) if self.accept_cond else ()
+
+        delta_time = zeros(batch_size, device = device)
+
+        for time in times:
+            time = time.expand(batch_size)
+            pred_flow = self.model(denoised, time, delta_time, *maybe_cond)
+            denoised = denoised - delta * pred_flow
+
+        return self.unnormalize_data_fn(denoised)
+
+    def sample(
+        self,
+        batch_size = None,
+        data_shape = None,
+        requires_grad = False,
+        cond = None,
+        noise = None,
+        steps = 1
+    ):
+        data_shape = default(data_shape, self.data_shape)
+
+        assert exists(data_shape), 'shape of the data must be passed in, or set at init or during training'
+
+        # maybe condition
+
+        maybe_cond = ()
+
+        if self.accept_cond:
+            batch_size = cond.shape[0]
+            maybe_cond = (cond,)
+
+        batch_size = default(batch_size, 1)
+
+        # maybe slow sample
+
+        assert steps >= 1
+
+        if steps > 1:
+            return self.slow_sample(
+                batch_size = batch_size,
+                data_shape = data_shape,
+                cond = cond,
+                steps = steps
+            )
+
+        assert xnor(self.accept_cond, exists(cond))
+        device = next(self.model.parameters()).device
+
+        context = nullcontext if requires_grad else torch.no_grad
+
+        # Algorithm 2
+
+        if not exists(noise):
+            noise = self.get_noise(batch_size, data_shape = data_shape)
+
+        with context():
+            denoised = noise - self.model(noise, ones(batch_size, device = device), ones(batch_size, device = device), *maybe_cond)
+
+        return self.unnormalize_data_fn(denoised)
+
+    def forward(
+        self,
+        data,
+        return_loss_breakdown = False,
+        cond = None,
+        noise = None
+    ):
+        assert xnor(self.accept_cond, exists(cond))
+
+        data = self.normalize_data_fn(data)
+
+        # shapes and variables
+
+        shape, ndim = data.shape, data.ndim
+
+        prob_time_end_start_same = self.prob_default_flow_obj
+
+        self.data_shape = default(self.data_shape, shape[1:]) # store last data shape for inference
+        batch, device = shape[0], data.device
+
+        # flow logic
+
+        times = self.sample_times(batch)
+
+        # some set prob of the time, normal flow matching training (times == start integral times)
+        # this enforces the boundary condition u(zt, t, t) = v(zt, t)
+
+        normal_flow_match_obj = prob_time_end_start_same > 0. and prob_time_end_start_same < random()
+
+        if normal_flow_match_obj:
+            integral_start_times = times # r = t for boundary condition
+        else:
+            integral_start_times = self.sample_times(batch) * times # restrict range to [0, times]
+
+        # derive flows
+
+        if not exists(noise):
+            noise = torch.randn_like(data) * self.noise_std_dev
+
+        flow = noise - data # flow is the velocity from data to noise
+
+        padded_times = append_dims(times, ndim - 1)
+        noised_data = data.lerp(noise, padded_times) # zt = (1-t)*x + t*noise
+
+        # condition the network on the delta times
+
+        delta_times = times - integral_start_times # (t - r)
+        padded_delta_times = append_dims(delta_times, ndim - 1)
+
+        # maybe condition
+
+        maybe_cond = (cond,) if self.accept_cond else ()
+
+        if normal_flow_match_obj:
+            # normal flow matching for boundary condition u(zt, t, t) = v(zt, t)
+
+            pred = self.model(noised_data, times, delta_times, *maybe_cond)
+            target = flow
+        else:
+            # algorithm 1 - interval splitting consistency
+
+            # sample lambda uniformly from [0, 1]
+            lambda_split = torch.rand(batch, device = device)
+            
+            # compute s = (1 - lambda) * t + lambda * r
+            split_times = (1 - lambda_split) * times + lambda_split * integral_start_times
+            
+            # compute u(zt, s, t) - velocity from s to t
+            delta_s_to_t = times - split_times
+            u2 = self.model(noised_data, times, delta_s_to_t, *maybe_cond)
+            
+            # compute zs = zt - (t - s) * u2
+            padded_delta_s_to_t = append_dims(delta_s_to_t, ndim - 1)
+            noised_data_s = noised_data - padded_delta_s_to_t * u2.detach() # detach for stop gradient
+            
+            # compute u(zs, r, s) - velocity from r to s
+            delta_r_to_s = split_times - integral_start_times
+            u1 = self.model(noised_data_s, split_times, delta_r_to_s, *maybe_cond)
+            
+            # the algebraic consistency target: u(zt, r, t) = (1 - lambda) * u1 + lambda * u2
+            lambda_split_padded = append_dims(lambda_split, ndim - 1)
+            target = (1 - lambda_split_padded) * u1.detach() + lambda_split_padded * u2.detach()
+            
+            # predict u(zt, r, t)
+            pred = self.model(noised_data, times, delta_times, *maybe_cond)
+
+        flow_loss = F.mse_loss(pred, target, reduction = 'none')
+
+        # section 4.3 of meanflow paper
+
+        if self.use_adaptive_loss_weight:
+            flow_loss = reduce(flow_loss, 'b ... -> b', 'mean')
+
+            p = self.adaptive_loss_weight_p
+            loss_weight = 1. / (flow_loss + self.eps).pow(p)
+
+            flow_loss = flow_loss * loss_weight.detach()
+
+        flow_loss = flow_loss.mean()
+
+        if not self.add_recon_loss:
+            if not return_loss_breakdown:
+                return flow_loss
+
+            return flow_loss, (flow_loss,)
+
+        # add predicted data recon loss, maybe adds stability
+
+        if normal_flow_match_obj:
+            pred_data = noised_data - pred * padded_times
+        else:
+            pred_data = noised_data - pred * padded_delta_times
+            
+        recon_loss = F.mse_loss(pred_data, data)
+
+        total_loss = (
+            flow_loss +
+            recon_loss * self.recon_loss_weight
+        )
+
+        if not return_loss_breakdown:
+            return total_loss
+
+        loss_breakdown = (flow_loss, recon_loss)
+
+        return total_loss, loss_breakdown

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -50,3 +50,73 @@ def test_mean_flow(
 
     sampled = mean_flow.sample(batch_size = 16, cond = cond)
     assert sampled.shape == data.shape
+
+
+@pytest.mark.parametrize('add_recon_loss', (False, True))
+@pytest.mark.parametrize('accept_cond', (False, True))
+@pytest.mark.parametrize('use_adaptive_loss_weight', (False, True))
+@pytest.mark.parametrize('prob_default_flow_obj', (0.0, 0.5, 1.0))  # different boundary condition probabilities
+def test_split_mean_flow(
+    add_recon_loss,
+    accept_cond,
+    use_adaptive_loss_weight,
+    prob_default_flow_obj
+):
+    from einx import add
+    from rectified_flow_pytorch.split_mean_flow import SplitMeanFlow
+
+    class Unet(Module):
+        def __init__(self):
+            super().__init__()
+            self.net = nn.Conv2d(3, 3, 1)
+        
+        def forward(self, x, t, r, cond = None):
+            # r represents delta_time (t - r_start) in the implementation
+            return add('b ..., b, b', self.net(x), t, r)
+    
+    model = Unet()
+    
+    split_mean_flow = SplitMeanFlow(
+        model, 
+        add_recon_loss = add_recon_loss, 
+        accept_cond = accept_cond, 
+        use_adaptive_loss_weight = use_adaptive_loss_weight,
+        prob_default_flow_obj = prob_default_flow_obj
+    )
+    
+    data = torch.randn(16, 3, 16, 16)
+    cond = data.clone() if accept_cond else None
+    
+    loss = split_mean_flow(data, cond = cond)
+    loss.backward()
+    
+    for param in model.parameters():
+        assert param.grad is not None
+        assert not torch.isnan(param.grad).any()
+    
+    for steps in [1, 2, 8]:
+        sampled = split_mean_flow.sample(
+            batch_size = 16, 
+            cond = cond,
+            steps = steps
+        )
+        assert sampled.shape == data.shape
+        assert not torch.isnan(sampled).any()
+    
+    noise = torch.randn_like(data)
+    sampled_with_noise = split_mean_flow.sample(
+        batch_size = 16,
+        cond = cond,
+        noise = noise
+    )
+    assert sampled_with_noise.shape == data.shape
+    
+    if add_recon_loss:
+        total_loss, (flow_loss, recon_loss) = split_mean_flow(
+            data, 
+            return_loss_breakdown = True,
+            cond = cond
+        )
+        assert isinstance(flow_loss, torch.Tensor)
+        assert isinstance(recon_loss, torch.Tensor)
+        assert torch.allclose(total_loss, flow_loss + recon_loss * split_mean_flow.recon_loss_weight)

--- a/train_split_mean_flow.py
+++ b/train_split_mean_flow.py
@@ -1,0 +1,57 @@
+import torch
+
+# hf datasets for easy oxford flowers training
+
+import torchvision.transforms as T
+from torch.utils.data import Dataset
+from datasets import load_dataset
+
+class OxfordFlowersDataset(Dataset):
+    def __init__(
+        self,
+        image_size
+    ):
+        self.ds = load_dataset('nelorth/oxford-flowers')['train']
+
+        self.transform = T.Compose([
+            T.Resize((image_size, image_size)),
+            T.PILToTensor()
+        ])
+
+    def __len__(self):
+        return len(self.ds)
+
+    def __getitem__(self, idx):
+        pil = self.ds[idx]['image']
+        tensor = self.transform(pil)
+        return tensor / 255.
+
+flowers_dataset = OxfordFlowersDataset(
+    image_size = 64
+)
+
+# models and trainer
+
+from rectified_flow_pytorch import SplitMeanFlow, Unet, Trainer
+
+model = Unet(
+    dim = 64,
+    dim_cond = 1,
+    accept_cond = True
+)
+
+split_mean_flow = SplitMeanFlow(
+    model,
+    normalize_data_fn = lambda t: t * 2. - 1.,
+    unnormalize_data_fn = lambda t: (t + 1.) / 2.
+)
+
+trainer = Trainer(
+    split_mean_flow,
+    dataset = flowers_dataset,
+    num_train_steps = 70_000,
+    learning_rate = 1e-4,
+    results_folder = './results'   # samples will be saved periodically to this folder
+)
+
+trainer()


### PR DESCRIPTION
New-ish paper from ByteDance Seed which removes the need for the jvp in MeanFlow: https://arxiv.org/abs/2507.16884

The main caveat is that they use a standard flow-based teacher model to bootstrap training for self-consistency. Maybe this could be approximated with some kind of warmup phase that prefers the boundary conditions earlier in training, e.g. t = 1 before splitting the intervals, but I haven't tried it yet.

(Not sure if you want this, feel free to close if not!)