### PR TITLE
SplitMeanFlow: Reverse flow direction to match NanoFlow and tweak conditioning for delta times

### DIFF
--- a/rectified_flow_pytorch/split_mean_flow.py
+++ b/rectified_flow_pytorch/split_mean_flow.py
@@ -99,19 +99,17 @@ class SplitMeanFlow(Module):
         if not exists(noise):
             noise = self.get_noise(batch_size, data_shape = data_shape)
 
-        times = torch.linspace(1., 0., steps + 1, device = device)[:-1]
+        times = torch.linspace(0., 1., steps + 1, device = device)[:-1]
         delta = 1. / steps
 
         denoised = noise
 
         maybe_cond = (cond,) if self.accept_cond else ()
 
-        delta_time = zeros(batch_size, device = device)
-
         for time in times:
             time = time.expand(batch_size)
-            pred_flow = self.model(denoised, time, delta_time, *maybe_cond)
-            denoised = denoised - delta * pred_flow
+            pred_flow = self.model(denoised, time, time, *maybe_cond)
+            denoised = denoised + delta * pred_flow
 
         return self.unnormalize_data_fn(denoised)
 
@@ -122,7 +120,7 @@ class SplitMeanFlow(Module):
         requires_grad = False,
         cond = None,
         noise = None,
-        steps = 1
+        steps = 4
     ):
         data_shape = default(data_shape, self.data_shape)
 
@@ -204,15 +202,14 @@ class SplitMeanFlow(Module):
         if not exists(noise):
             noise = torch.randn_like(data)
 
-        flow = noise - data # flow is the velocity from data to noise
+        flow = data - noise # flow is the velocity from data to noise
 
         padded_times = append_dims(times, ndim - 1)
-        noised_data = data.lerp(noise, padded_times) # zt = (1-t)*x + t*noise
+        noised_data = noise.lerp(data, padded_times) # noise the data with random amounts of noise (time) - lerp is read as noise -> data from 0. to 1.
 
         # condition the network on the delta times
 
         delta_times = times - integral_start_times # (t - r)
-        padded_delta_times = append_dims(delta_times, ndim - 1)
 
         # maybe condition
 
@@ -221,7 +218,7 @@ class SplitMeanFlow(Module):
         if normal_flow_match_obj:
             # normal flow matching for boundary condition u(zt, t, t) = v(zt, t)
 
-            pred = self.model(noised_data, times, delta_times, *maybe_cond)
+            pred = self.model(noised_data, times, times, *maybe_cond)
             target = flow
         else:
             # algorithm 1 - interval splitting consistency
@@ -268,6 +265,7 @@ class SplitMeanFlow(Module):
         if normal_flow_match_obj:
             pred_data = noised_data - pred * padded_times
         else:
+            padded_delta_times = append_dims(delta_times, ndim - 1)
             pred_data = noised_data - pred * padded_delta_times
             
         recon_loss = F.mse_loss(pred_data, data)

--- a/rectified_flow_pytorch/split_mean_flow.py
+++ b/rectified_flow_pytorch/split_mean_flow.py
@@ -120,7 +120,7 @@ class SplitMeanFlow(Module):
         requires_grad = False,
         cond = None,
         noise = None,
-        steps = 4
+        steps = 2
     ):
         data_shape = default(data_shape, self.data_shape)
 

--- a/rectified_flow_pytorch/split_mean_flow.py
+++ b/rectified_flow_pytorch/split_mean_flow.py
@@ -202,7 +202,7 @@ class SplitMeanFlow(Module):
         if not exists(noise):
             noise = torch.randn_like(data)
 
-        flow = data - noise # flow is the velocity from data to noise
+        flow = data - noise # flow is the velocity from noise to data
 
         padded_times = append_dims(times, ndim - 1)
         noised_data = noise.lerp(data, padded_times) # noise the data with random amounts of noise (time) - lerp is read as noise -> data from 0. to 1.


### PR DESCRIPTION
I noticed that the MeanFlow implementation (which this is based on) flows from data -> noise, which I find much harder to reason through. I switched this to the typical/NanoFlow style to flow from noise -> data along [0, 1] and verified the normal flow matching objective case matches NanoFlow training.

I also tweaked the conditioning to provide 1) the full time deltas in the normal case, and 2) the partial time deltas in the split case, which gives us a consistent representation for time deltas, and set the default sampling steps to 2 which more closely mirrors the paper's objective.

It's still finding trivial split-step solutions when training from scratch for the case when `normal_flow_match_obj` < 1.0, but a schedule or the multi-stage training should help resolve that, and it the model now converges on pretty reasonable results when using 0.8-0.9 -- here's a sample at 4k training steps:

<img width="256" height="256" alt="4k-steps" src="https://github.com/user-attachments/assets/225e064a-ee0c-4683-937d-c876456c3a04" />
