### PR TITLE
fix(reflow): add the imports ReflowTrainer needs (math, rearrange, save_image, divisible_by)

### DIFF
--- a/rectified_flow_pytorch/reflow.py
+++ b/rectified_flow_pytorch/reflow.py
@@ -1,9 +1,13 @@
+import math
 from copy import deepcopy
 from pathlib import Path
 
 import torch
 from torch.optim import Adam
 from torch.nn import Module, ModuleList
+from torchvision.utils import save_image
+
+from einops import rearrange
 
 from rectified_flow_pytorch.rectified_flow import RectifiedFlow
 
@@ -17,6 +21,9 @@ def exists(v):
 
 def default(v, d):
     return v if exists(v) else d
+
+def divisible_by(num, den):
+    return (num % den) == 0
 
 # reflow wrapper
 


### PR DESCRIPTION
`ReflowTrainer` in `rectified_flow_pytorch/reflow.py` is a copy of the `Trainer` in `rectified_flow.py`, but none of the module-level names that copy depends on were brought along. `reflow.py` imports only `torch`, `Adam`, `Module`/`ModuleList`, `RectifiedFlow`, `EMA` and `Accelerator`, so five uses are undefined:

| line | expression | missing name |
|---|---|---|
| 122 | `self.num_sample_rows = int(math.sqrt(num_samples))` | `math` |
| 174 | `if divisible_by(step, self.save_results_every):` | `divisible_by` |
| 180 | `sampled = rearrange(sampled, '(row col) c h w -> ...')` | `rearrange` |
| 185 | `save_image(sampled, str(self.results_folder / ...))` | `save_image` |
| 187 | `if divisible_by(step, self.checkpoint_every):` | `divisible_by` |

Line 122 is in `__init__`, so `ReflowTrainer` raises `NameError` the moment it is constructed — and it is part of the public API (`from rectified_flow_pytorch import ReflowTrainer` in `__init__.py`). The other three are on the training loop's sampling/checkpoint path.

### Spec

`Trainer` in `rectified_flow.py` is the same code with the imports present — `import math` (line 3), `from torchvision.utils import save_image` (line 18), `from einops import ... rearrange ...` (line 22), `def divisible_by` (line 556) — and it uses them at the mirrored lines 1176 / 1276 / 1277 / 1325 / 1331. `divisible_by` is defined locally in `fit.py`, `lsd_flow.py` and `soflow.py` too, so this patch follows the same convention rather than importing it.

### Verification

`ReflowTrainer.__init__` and `.forward` were extracted with `ast.get_source_segment`, compiled, and replayed against stubbed collaborators (`Accelerator`, `EMA`, `Adam`, model, optimizer) with `num_samples = 16`, `num_train_steps = 1`, `save_results_every = 1`:

```
BEFORE  ReflowTrainer.__init__(num_samples=16) -> NameError: name 'math' is not defined
AFTER   ReflowTrainer.__init__(num_samples=16) -> OK  num_sample_rows=4

BEFORE  ReflowTrainer.forward() 1 step         -> NameError: name 'divisible_by' is not defined
AFTER   ReflowTrainer.forward() 1 step         -> OK  completed 1 training step (sampled grid written)
```

`pyflakes rectified_flow_pytorch/reflow.py` goes from five `undefined name` reports to zero. Imports only, +7/-0, no behaviour change to anything that already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
